### PR TITLE
update settings, add boot to bios, broadcast and region options

### DIFF
--- a/game.libretro.reicast/resources/language/English/strings.po
+++ b/game.libretro.reicast/resources/language/English/strings.po
@@ -25,29 +25,41 @@ msgid "CPU Mode"
 msgstr ""
 
 msgctxt "#30002"
-msgid "Internal resolution"
+msgid "Boot to BIOS"
 msgstr ""
 
 msgctxt "#30003"
-msgid "Mipmapping"
+msgid "Internal resolution"
 msgstr ""
 
 msgctxt "#30004"
-msgid "Widescreen hack"
+msgid "Mipmapping"
 msgstr ""
 
 msgctxt "#30005"
-msgid "Audio buffer size"
+msgid "Widescreen hack"
 msgstr ""
 
 msgctxt "#30006"
-msgid "Cable type"
+msgid "Audio buffer size"
 msgstr ""
 
 msgctxt "#30007"
-msgid "Precompile shaders"
+msgid "Cable type"
 msgstr ""
 
 msgctxt "#30008"
+msgid "Broadcast"
+msgstr ""
+
+msgctxt "#30009"
+msgid "Region"
+msgstr ""
+
+msgctxt "#30010"
+msgid "Precompile shaders"
+msgstr ""
+
+msgctxt "#30011"
 msgid "Enable RTT (Render To Texture)"
 msgstr ""

--- a/game.libretro.reicast/resources/settings.xml
+++ b/game.libretro.reicast/resources/settings.xml
@@ -2,12 +2,15 @@
 <settings>
 	<category label="30000">
 		<setting label="30001" type="labelenum" id="reicast_cpu_mode" values="dynamic_recompiler|generic_recompiler" default="dynamic_recompiler"/>
-		<setting label="30002" type="labelenum" id="reicast_internal_resolution" values="640x480|1280x960|1920x1440|2560x1920|3200x2400|3840x2880|4480x3360" default="640x480"/>
-		<setting label="30003" type="labelenum" id="reicast_mipmapping" values="enabled|disabled" default="enabled"/>
-		<setting label="30004" type="labelenum" id="reicast_widescreen_hack" values="disabled|enabled" default="disabled"/>
-		<setting label="30005" type="labelenum" id="reicast_audio_buffer_size" values="1024|2048" default="1024"/>
-		<setting label="30006" type="labelenum" id="reicast_cable_type" values="TV (VBS/Y+S/C)|TV (RGB)|VGA (0)(RGB)|VGA (1)(RGB)" default="TV (VBS/Y+S/C)"/>
-		<setting label="30007" type="labelenum" id="reicast_precompile_shaders" values="disabled|enabled" default="disabled"/>
-		<setting label="30008" type="labelenum" id="reicast_enable_rtt" values="enabled|disabled" default="enabled"/>
+		<setting label="30002" type="labelenum" id="reicast_boot_to_bios" values="disabled|enabled" default="disabled"/>
+		<setting label="30003" type="labelenum" id="reicast_internal_resolution" values="640x480|1280x960|1920x1440|2560x1920|3200x2400|3840x2880|4480x3360" default="640x480"/>
+		<setting label="30004" type="labelenum" id="reicast_mipmapping" values="enabled|disabled" default="enabled"/>
+		<setting label="30005" type="labelenum" id="reicast_widescreen_hack" values="disabled|enabled" default="disabled"/>
+		<setting label="30006" type="labelenum" id="reicast_audio_buffer_size" values="1024|2048" default="1024"/>
+		<setting label="30007" type="labelenum" id="reicast_cable_type" values="TV (VBS/Y+S/C)|TV (RGB)|VGA (RGB)" default="TV (VBS/Y+S/C)"/>
+		<setting label="30008" type="labelenum" id="reicast_broadcast" values="0|1|2|3|4" default="4"/>
+		<setting label="30009" type="labelenum" id="reicast_region" values="0|1|2|3" default="3"/>
+		<setting label="30010" type="labelenum" id="reicast_precompile_shaders" values="disabled|enabled" default="disabled"/>
+		<setting label="30011" type="labelenum" id="reicast_enable_rtt" values="enabled|disabled" default="enabled"/>
 	</category>
 </settings>


### PR DESCRIPTION
This follows the last few commits in libretro/reicast-emulator

libretro/reicast-emulator@35231e64c5fca1fc33c53a67ea36e3f69beb48d9
libretro/reicast-emulator@413a28ca8554a5cd4f1486bbd1fc69f57b6d5b29
libretro/reicast-emulator@0818d92900b278bd7c0f2c0a5d5bee6a787522a8

I've kept the settings in the order that they are listed
