### PR TITLE
Attach the Dreamcast controller as a device Flycast recognises

### DIFF
--- a/game.libretro.flycast/resources/buttonmap.xml
+++ b/game.libretro.flycast/resources/buttonmap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <buttonmap version="2">
-    <controller id="game.controller.dreamcast" type="RETRO_DEVICE_ANALOG">
+    <controller id="game.controller.dreamcast" type="RETRO_DEVICE_JOYPAD">
         <feature name="a" mapto="RETRO_DEVICE_ID_JOYPAD_B"/>
         <feature name="b" mapto="RETRO_DEVICE_ID_JOYPAD_A"/>
         <feature name="x" mapto="RETRO_DEVICE_ID_JOYPAD_Y"/>


### PR DESCRIPTION
The Dreamcast controller never attaches, so no input reaches the game.

`resources/buttonmap.xml` declares the controller as `RETRO_DEVICE_ANALOG`.
That is not among the devices Flycast declares in its
`retro_controller_description` list, so `retro_set_controller_port_device()`
falls to its `default:` case and attaches `MDT_None` — every port comes up with
nothing plugged into it.

`RETRO_DEVICE_JOYPAD` is what Flycast calls its standard controller. The analog
sticks are read through input descriptors either way, so nothing is lost by the
change.

Found while testing Dreamcast games in Kodi; the fix is independent of that work
and applies to anyone using this add-on today.
