### PR TITLE
Map the Dreamcast triggers to the ids flycast reads them on

### DIFF
--- a/game.libretro.flycast/resources/buttonmap.xml
+++ b/game.libretro.flycast/resources/buttonmap.xml
@@ -10,8 +10,8 @@
         <feature name="down" mapto="RETRO_DEVICE_ID_JOYPAD_DOWN"/>
         <feature name="right" mapto="RETRO_DEVICE_ID_JOYPAD_RIGHT"/>
         <feature name="left" mapto="RETRO_DEVICE_ID_JOYPAD_LEFT"/>
-        <feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L"/>
-        <feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R"/>
+        <feature name="lefttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_L2"/>
+        <feature name="righttrigger" mapto="RETRO_DEVICE_ID_JOYPAD_R2"/>
         <feature name="analogstick" mapto="RETRO_DEVICE_INDEX_ANALOG_LEFT"/>
         <feature name="leftmotor" mapto="RETRO_RUMBLE_STRONG"/>
         <feature name="rightmotor" mapto="RETRO_RUMBLE_WEAK"/>


### PR DESCRIPTION
The Dreamcast triggers currently do nothing.

They were mapped to `RETRO_DEVICE_ID_JOYPAD_L` and `_R`. flycast declares those as "Button 5" and "Button 6" of its arcade stick layout, and puts the analog triggers on L2/R2 — libretro's convention for analog triggers:

```c
desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_L2, "L Trigger" };
desc[descriptor_index++] = { i, RETRO_DEVICE_JOYPAD, 0, RETRO_DEVICE_ID_JOYPAD_R2, "R Trigger" };
```

### How it showed up

Crazy Taxi is unplayable — accelerate and brake are the triggers, so the car won't move. It isn't obvious from the symptom because every other button works normally, which makes it look like a game or emulation problem rather than a mapping one.

### Testing

Found by comparing the add-on's buttonmap against the descriptor table in the pinned core source, then confirmed against the "L Trigger"/"R Trigger" descriptions flycast reports. I'll follow up here once I've confirmed Crazy Taxi drives on hardware with this applied.

`reicast` has the identical mapping and the same bug.
